### PR TITLE
Implement periodic update with python scheduler and PM2 as service manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ pkg/*
 src/*
 *.tar.xz
 *.tar.zst
+
+.vscode/*
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,6 +9,7 @@ url="https://github.com/felinae98/clashup"
 depends=(python
          clash
          python-requests
+         python-schedule
          python-daemon)
 source=(clashup clashup.conf clashup.service clashup.timer)
 package() {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ git clone https://github.com/felinae98/clashup && cd clashup
 $ chmod +x clashup
 
 # Copy script to /usr/local/bin
-$ cp clashup /usr/local/bin/
+$ sudo cp clashup /usr/local/bin/
 
 # Verify that clashup is in $PATH, executable, and works as expected
 $ clashup --update

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ An active system-wide installation of Python 3 is required as well as extra Pyth
 $ sudo apt install python-is-python3
 
 # 2. Install libraries for system-installed Python 3
-$ sudo apt install python3-requests
-$ sudo apt install python3-daemon
+$ sudo apt install python3-requests python3-daemon python3-schedule
 
 # 3. Install PM2 and start clash
 $ wget -qO- https://getpm2.com/install.sh | bash
@@ -64,14 +63,19 @@ $ sudo cp clashup /usr/local/bin/
 $ clashup --update
 ```
 
-Finally enable `clashup` using PM2 with CRON enabled:
+You will need to edit configuration file `~/.config/clash/clashup.json`, specifially:
+
+* Set `pm2` as true.
+* Set `periodically_update` as true.
+
+Finally enable `clashup` using PM2:
 
 ```sh
 # Start clash with PM2 first
 $ pm2 start clash
 
-# Then start clashup with CRON job "at 12:00:00 PM every day"
-$ pm2 start clashup --cron "0 0 12 ? * * *"
+# Then start clashup
+$ pm2 start /usr/local/bin/clashup --interpreter python
 ```
 
 You might want to also enable PM2 on startup:
@@ -85,7 +89,7 @@ $ pm2 save
 
 ## Configurations
 
-The config file is `~/.config/clash/clashup.json`
+The config file is `~/.config/clash/clashup.json`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1,50 +1,142 @@
 # clashup
 
-An updator for clash on Archlinux
+An updater for Clash on Linux.
 
-## Install 
-`$ git clone https://github.com/felinae98/clashup.git && cd clashup && makepkg -si`
+- [Installation](#installation)
+  - [For Arch Linux](#for-arch-linux)
+  - [Manually enable for other distros](#manually-enable-for-other-distros)
+- [Configurations](#configurations)
+- [How it works](#how-it-works)
+- [FAQ](#faq)
+
+## Installation
+
+### For Arch Linux
+
+```sh
+$ git clone https://github.com/felinae98/clashup.git && cd clashup && makepkg -si
+```
 
 or use aur
 
-`yay -Sy clashup`
+```sh
+$ yay -Sy clashup
+```
 
 and just
 
-`$ systemctl --user start clash`
+```sh
+$ systemctl --user start clash
+```
 
-## Config
+### Manually enable for other distros
+
+Clash on Linux is generally more managable with PM2 as a service manager. We will leverage PM2 to run both clash and clashup here. (See [Clash as a daemon](https://github.com/Dreamacro/clash/wiki/clash-as-a-daemon).)
+
+An active system-wide installation of Python 3 is required as well as extra Python dependencies including `python3-requests` and `python3-daemon` (primarily for updating mmdb as a subprocess):
+
+```sh
+# On Ubuntu for instance:
+# 1. Use Python 3 as system default Python
+$ sudo apt install python-is-python3
+
+# 2. Install libraries for system-installed Python 3
+$ sudo apt install python3-requests
+$ sudo apt install python3-daemon
+
+# 3. Install PM2 and start clash
+$ wget -qO- https://getpm2.com/install.sh | bash
+$ pm2 start clash
+```
+
+Then simply copy `clashup` to `/usr/local/bin`:
+
+```sh
+$ git clone https://github.com/felinae98/clashup && cd clashup
+
+# Make script executable
+$ chmod +x clashup
+
+# Copy script to /usr/local/bin
+$ cp clashup /usr/local/bin/
+
+# Verify that clashup is in $PATH, executable, and works as expected
+$ clashup --update
+```
+
+Finally enable `clashup` using PM2 with CRON enabled:
+
+```sh
+# Start clash with PM2 first
+$ pm2 start clash
+
+# Then start clashup with CRON job "at 12:00:00 PM every day"
+$ pm2 start clashup --cron "0 0 12 ? * * *"
+```
+
+You might want to also enable PM2 on startup:
+
+```sh
+$ pm2 startup
+# Which generates a command to paste and execute, you'll need to execute the command manually
+
+$ pm2 save
+```
+
+## Configurations
+
 The config file is `~/.config/clash/clashup.json`
+
 ```json
 {
     "http_port": 7890,
     "socks5_port": 7891,
-    "redir_port": 7892, 
+    "redir_port": 7892,
+    "mixed_port": 7893,
     "allow_lan": true,
     "external_controller": "127.0.0.1:9090",
+    "external_ui": "dashboard",
     "subscribe_url": "",
-    "is_subscribe_banned": false, 
+    "is_subscribe_banned": false,
     "custom_rules": [],
     "mmdb_file_url": "http://www.ideame.top/mmdb/Country.mmdb",
     "mmdb_version_url": "http://www.ideame.top/mmdb/version"
 }
 ```
-* Set `is_subscribe_banned` true if your subscribe address was banned.
-* `http_port` is required if `is_subscribe_banned` is true
+
+* Set `is_subscribe_banned` to true if your subscribe address was banned.
+* `http_port` is required if `is_subscribe_banned` is true.
+* If you use external dashboard such as [yacd](https://github.com/haishanh/yacd), you can define `external_ui` as the folder name of the static webpage (default is `dashboard`) and put your downloaded static dashboard page inside directory `./dashboard`.
 * If you both set `mmdb_file_url` and `mmdb_version_url` it will update `Country.mmdb` file every start up time.
+
 ## How it works
-It just simply download the subscribe config file and override `http-port`, `socks-port`, `redir-port`, `allow-lan`, `external-controller` in the config file, and append `custom_rules` to `Rules`.
 
-If your can access your subscribe url directly, it just download and update config file before clash start.
+`clashup` simply downloads the remote subscription file and override `http-port`, `socks-port`, `redir-port`, `mixed-port`, `allow-lan`, `external-controller`, and `external-ui` in the config file, and append `custom_rules` to `Rules`.
 
-Otherwise your subscribe url is banned, it download and update the config file after clash start and then restart clash.
+If your can access your subscription url directly, it will download and update config file before clash start. Otherwise (if your subscription url is banned), `clashup` will download and update the config file after starting clash and then restart clash.
 
 ## FAQ
 
-* How to see log
-  
-    `journalctl --user -u clash -e`
+* How to see log:
+    * For Arch Linux:
+        ```sh
+        journalctl --user -u clash -e
+        ```
+    * For other distros using PM2:
+        ```sh
+        pm2 logs
+        ```
 
-* How to add custom rules
+* How to add custom rules:
 
-    edit `~/.config/clash/clashup.json` and `systemctl --user restart clash`
+    Edit `~/.config/clash/clashup.json` and:
+
+    * For Arch Linux:
+        ```sh
+        systemctl --user restart clash
+        ```
+    * For other distros using PM2:
+        ```sh
+        pm2 restart clash
+        pm2 restart clashup
+        ```

--- a/clashup
+++ b/clashup
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import requests
-import yaml
+import argparse
+import hashlib
 import json
+import logging
 import os
 import shutil
-import logging
-import time
-import argparse
 import subprocess
-import hashlib
-import daemon
+import sys
+import time
 
-logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=logging.INFO)
+import daemon
+import requests
+import yaml
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s: %(message)s",
+    level=logging.INFO,
+    stream=sys.stdout,
+)
 
 
 class ClashUp:

--- a/clashup
+++ b/clashup
@@ -13,6 +13,7 @@ import time
 
 import daemon
 import requests
+import schedule
 import yaml
 
 logging.basicConfig(
@@ -172,11 +173,15 @@ class ClashUp:
         parser.add_argument("--post", action="store_true")
         parser.add_argument("--update", action="store_true")
         args = parser.parse_args()
-        self.load_conf()
-        if args.update:
+
+        def update_subscription():
             self.update(False)
             self.update_mmdb()
             self.restart_clash()
+
+        self.load_conf()
+        if args.update:
+            update_subscription()
         elif args.pre and not self.config.get("periodically_update", False):
             if self.config["is_subscribe_banned"]:
                 logging.info("Subscribe is banned, pass this run")
@@ -194,6 +199,14 @@ class ClashUp:
                     logging.info("config file updated in 24h, pass this run")
             else:
                 logging.info("pass this run")
+        elif self.config.get("periodically_update", False):
+            schedule.every().day.at("12:00").do(update_subscription)
+            try:
+                while True:
+                    schedule.run_pending()
+                    time.sleep(60)
+            except KeyboardInterrupt:
+                logging.info("exiting gracefully.")
         else:
             parser.print_usage()
 

--- a/clashup
+++ b/clashup
@@ -200,6 +200,7 @@ class ClashUp:
             else:
                 logging.info("pass this run")
         elif self.config.get("periodically_update", False):
+            update_subscription()
             schedule.every().day.at("12:00").do(update_subscription)
             try:
                 while True:

--- a/clashup
+++ b/clashup
@@ -31,7 +31,8 @@ class ClashUp:
     "custom_rules": [],
     "mmdb_file_url": "http://www.ideame.top/mmdb/Country.mmdb",
     "mmdb_version_url: "http://www.ideame.top/mmdb/version",
-    "periodically_update": false
+    "periodically_update": false,
+    "pm2": false
 }
 """
 
@@ -49,7 +50,9 @@ class ClashUp:
         if not os.path.isfile(self.conf_file_path):
             with open(self.conf_file_path, "w") as f:
                 f.write(self.EXAMPLE_CONF)
-            raise OSError("plz edit ~/.config/clash/clashup.json")
+            raise OSError(
+                "plz edit ~/.config/clash/clashup.json, set 'pm2' as true if using PM2"
+            )
         with open(self.conf_file_path) as f:
             raw_config_text = f.read()
             raw_config = json.loads(raw_config_text)
@@ -133,6 +136,12 @@ class ClashUp:
         except requests.exceptions.RequestException:
             logging.warning("Update mmdb failed")
 
+    def restart_clash(self):
+        if self.config.get("pm2", False):
+            subprocess.run(["pm2", "restart", "clash"])
+        else:
+            subprocess.run(["systemctl", "--user", "restart", "clash"])
+
     def update_time_cache(self):
         if not os.path.isfile(self.cache_file_path):
             self._write_cache()
@@ -161,6 +170,7 @@ class ClashUp:
         if args.update:
             self.update(False)
             self.update_mmdb()
+            self.restart_clash()
         elif args.pre and not self.config.get("periodically_update", False):
             if self.config["is_subscribe_banned"]:
                 logging.info("Subscribe is banned, pass this run")
@@ -173,11 +183,13 @@ class ClashUp:
             if self.config["is_subscribe_banned"]:
                 if self.update_time_cache():
                     self.update(True)
-                    subprocess.run(["systemctl", "--user", "restart", "clash"])
+                    self.restart_clash()
                 else:
                     logging.info("config file updated in 24h, pass this run")
             else:
                 logging.info("pass this run")
+        else:
+            parser.print_usage()
 
 
 if __name__ == "__main__":

--- a/clashup
+++ b/clashup
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import requests
 import yaml
@@ -12,17 +13,19 @@ import subprocess
 import hashlib
 import daemon
 
-logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s', level=logging.INFO)
+logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=logging.INFO)
+
 
 class ClashUp:
 
-    EXAMPLE_CONF = '''{
+    EXAMPLE_CONF = """{
     "http_port": 7890,
     "socks5_port": 7891,
     "redir_port": 7892,
     "mixed_port": 7893,
     "allow_lan": true,
     "external_controller": "127.0.0.1:9090",
+    "external_ui": "dashboard",
     "subscribe_url": "",
     "is_subscribe_banned": false,
     "custom_rules": [],
@@ -30,27 +33,28 @@ class ClashUp:
     "mmdb_version_url: "http://www.ideame.top/mmdb/version",
     "periodically_update": false
 }
-'''
+"""
+
     def __init__(self):
-        self.conf_file_path = os.path.expanduser('~/.config/clash/clashup.json')
-        self.clash_conf_path = os.path.expanduser('~/.config/clash/config.yaml')
-        self.clash_conf_path_old = os.path.expanduser('~/.config/clash/config.yaml.old')
-        self.cache_file_path = os.path.expanduser('~/.cache/clashup')
-        self.mmdb_version_file = os.path.expanduser('~/.cache/clashup-mmdb')
-        self.mmdb_file_path = os.path.expanduser('~/.config/clash/Country.mmdb')
+        self.conf_file_path = os.path.expanduser("~/.config/clash/clashup.json")
+        self.clash_conf_path = os.path.expanduser("~/.config/clash/config.yaml")
+        self.clash_conf_path_old = os.path.expanduser("~/.config/clash/config.yaml.old")
+        self.cache_file_path = os.path.expanduser("~/.cache/clashup")
+        self.mmdb_version_file = os.path.expanduser("~/.cache/clashup-mmdb")
+        self.mmdb_file_path = os.path.expanduser("~/.config/clash/Country.mmdb")
         self.session = requests.Session()
         self.session.trust_env = False
 
     def load_conf(self):
         if not os.path.isfile(self.conf_file_path):
-            with open(self.conf_file_path, 'w') as f:
+            with open(self.conf_file_path, "w") as f:
                 f.write(self.EXAMPLE_CONF)
-            raise OSError('plz edit ~/.config/clash/clashup.json')
+            raise OSError("plz edit ~/.config/clash/clashup.json")
         with open(self.conf_file_path) as f:
             raw_config_text = f.read()
             raw_config = json.loads(raw_config_text)
-        if not raw_config.get('subscribe_url'):
-            raise ValueError('subscribe_url can not be empty')
+        if not raw_config.get("subscribe_url"):
+            raise ValueError("subscribe_url can not be empty")
         self.config = raw_config
         hash_item = hashlib.sha256(raw_config_text.encode())
         self.config_hash = hash_item.hexdigest()
@@ -58,73 +62,84 @@ class ClashUp:
     def download(self, use_proxy=False):
         if use_proxy:
             proxy = {
-                'http': 'http://127.0.0.1:{}'.format(self.config['http_port']),
-                'https': 'http://127.0.0.1:{}'.format(self.config['http_port'])
+                "http": "http://127.0.0.1:{}".format(self.config["http_port"]),
+                "https": "http://127.0.0.1:{}".format(self.config["http_port"]),
             }
-            res = self.session.get(self.config['subscribe_url'], timeout=5, proxies=proxy)
+            res = self.session.get(
+                self.config["subscribe_url"], timeout=5, proxies=proxy
+            )
         else:
-            res = self.session.get(self.config['subscribe_url'], timeout=5, proxies={'http': None, 'https': None})
+            res = self.session.get(
+                self.config["subscribe_url"],
+                timeout=5,
+                proxies={"http": None, "https": None},
+            )
         res.raise_for_status()
         raw_clash_conf = yaml.safe_load(res.text)
         return raw_clash_conf
-    
+
     def _load_conf(self, config, local_config_key, config_key):
         if local_config_key in self.config:
             config[config_key] = self.config[local_config_key]
 
     def parse_config(self, config):
-        self._load_conf(config, 'http_port', 'port')
-        self._load_conf(config, 'socks5_port', 'socks-port')
-        self._load_conf(config, 'redir_port', 'redir-port')
-        self._load_conf(config, 'mixed_port', 'mixed-port')
-        self._load_conf(config, 'allow_lan', 'allow-lan')
-        self._load_conf(config, 'external_controller', 'external-controller')
-        config['rules'] = self.config.get('custom_rules', []) + config.get('rules', [])
+        self._load_conf(config, "http_port", "port")
+        self._load_conf(config, "socks5_port", "socks-port")
+        self._load_conf(config, "redir_port", "redir-port")
+        self._load_conf(config, "mixed_port", "mixed-port")
+        self._load_conf(config, "allow_lan", "allow-lan")
+        self._load_conf(config, "external_controller", "external-controller")
+        self._load_conf(config, "external_ui", "external-ui")
+        config["rules"] = self.config.get("custom_rules", []) + config.get("rules", [])
         return config
 
     def save(self, config):
         if os.path.isfile(self.clash_conf_path):
             shutil.move(self.clash_conf_path, self.clash_conf_path_old)
-        with open(self.clash_conf_path, 'w') as f:
+        with open(self.clash_conf_path, "w") as f:
             f.write(yaml.safe_dump(config))
 
     def update(self, use_proxy):
-        logging.info('Update Start')
+        logging.info("Update Start")
         try:
             raw_clash_conf = self.download(use_proxy)
             parsed_clash_conf = self.parse_config(raw_clash_conf)
             self.save(parsed_clash_conf)
-            logging.info('Update Finish')
+            logging.info("Update Finish")
         except requests.exceptions.RequestException:
-            logging.warning('Update Fail')
+            logging.warning("Update Fail")
 
     def update_mmdb(self):
         try:
-            resp = self.session.get(self.config['mmdb_version_url'], proxies={'http': None, 'https': None})
+            resp = self.session.get(
+                self.config["mmdb_version_url"], proxies={"http": None, "https": None}
+            )
             resp.raise_for_status()
             current_version = resp.text
             if os.path.isfile(self.mmdb_version_file):
-                with open(self.mmdb_version_file, 'r') as f:
+                with open(self.mmdb_version_file, "r") as f:
                     if current_version == f.read():
-                        logging.info('pass mmdb update')
+                        logging.info("pass mmdb update")
                         return
-            resp = self.session.get(self.config['mmdb_file_url'], proxies={'http': None, 'https': None})
+            resp = self.session.get(
+                self.config["mmdb_file_url"], proxies={"http": None, "https": None}
+            )
             resp.raise_for_status()
-            with open(self.mmdb_file_path, 'wb') as f:
+            with open(self.mmdb_file_path, "wb") as f:
                 f.write(resp.content)
-            with open(self.mmdb_version_file, 'w') as f:
+            with open(self.mmdb_version_file, "w") as f:
                 f.write(current_version)
-            logging.info('Update mmdb')
+            logging.info("Update mmdb")
         except requests.exceptions.RequestException:
-            logging.warning('Update mmdb failed')
+            logging.warning("Update mmdb failed")
 
     def update_time_cache(self):
         if not os.path.isfile(self.cache_file_path):
             self._write_cache()
             return True
         else:
-            with open(self.cache_file_path, 'r') as f:
-                cache_text = f.read().split('-')
+            with open(self.cache_file_path, "r") as f:
+                cache_text = f.read().split("-")
             last_time = float(cache_text[1])
             if cache_text[0] != self.config_hash or time.time() - last_time > 86400:
                 self._write_cache()
@@ -133,37 +148,37 @@ class ClashUp:
                 return False
 
     def _write_cache(self):
-        with open(self.cache_file_path, 'w') as f:
-            f.write('{}-{}'.format(self.config_hash, time.time()))
+        with open(self.cache_file_path, "w") as f:
+            f.write("{}-{}".format(self.config_hash, time.time()))
 
     def run(self):
         parser = argparse.ArgumentParser()
-        parser.add_argument('--pre', action='store_true')
-        parser.add_argument('--post', action='store_true')
-        parser.add_argument('--update', action='store_true')
+        parser.add_argument("--pre", action="store_true")
+        parser.add_argument("--post", action="store_true")
+        parser.add_argument("--update", action="store_true")
         args = parser.parse_args()
         self.load_conf()
         if args.update:
             self.update(False)
             self.update_mmdb()
-        elif args.pre and not self.config.get('periodically_update', False):
-            if self.config['is_subscribe_banned']:
-                logging.info('Subscribe is banned, pass this run')
+        elif args.pre and not self.config.get("periodically_update", False):
+            if self.config["is_subscribe_banned"]:
+                logging.info("Subscribe is banned, pass this run")
             else:
                 self.update(False)
-            if self.config.get('mmdb_version_url') and self.config.get('mmdb_file_url'):
+            if self.config.get("mmdb_version_url") and self.config.get("mmdb_file_url"):
                 with daemon.DaemonContext():
                     self.update_mmdb()
-        elif args.post and not self.config.get('periodically_update', False):
-            if self.config['is_subscribe_banned']:
+        elif args.post and not self.config.get("periodically_update", False):
+            if self.config["is_subscribe_banned"]:
                 if self.update_time_cache():
                     self.update(True)
-                    subprocess.run(['systemctl', '--user', 'restart', 'clash'])
+                    subprocess.run(["systemctl", "--user", "restart", "clash"])
                 else:
-                    logging.info('config file updated in 24h, pass this run')
+                    logging.info("config file updated in 24h, pass this run")
             else:
-                logging.info('pass this run')
+                logging.info("pass this run")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     ClashUp().run()


### PR DESCRIPTION
### New features

This pull request implements:

* Periodic updates (hard-coded as 12:00PM every day) through Python [schedule](https://github.com/dbader/schedule)
* Documentations for usage with PM2 on distros other than Arch Linux

### Fixes

This pull request also addresses the following issues:

* Add `external_ui` as an extra option in Clash's `config.yaml`
* Output logs to `stdout` instead of `stderr` (for PM2 to catch output in regular logs instead of error logs)
* Various grammar issues
* Formatted with `black`

### TO-DOs

- [ ] Configurable update time
- [ ] Taking care of `is_subscribe_banned` in periodic update mode
- [ ] Package as single executable 